### PR TITLE
Install dependencies in ci with uv

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,8 @@ jobs:
                 python-version: '3.x'
             - name: Install dependencies
               run: |
-                python -m pip install --upgrade pip setuptools wheel
-                pip install -r requirements.txt
+                python -m pip install uv
+                uv pip install --upgrade pip setuptools wheel
+                uv pip install -r requirements.txt
             - name: Test with unittest
               run: python -m unittest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,8 +19,8 @@ jobs:
                 python-version: '3.x'
             - name: Install dependencies
               run: |
-                python -m pip install uv
-                uv pip install --upgrade pip setuptools wheel
-                uv pip install -r requirements.txt
+                python -m pip install --upgrade uv
+                uv pip install --system --upgrade pip setuptools wheel
+                uv pip install --system -r requirements.txt
             - name: Test with unittest
               run: python -m unittest


### PR DESCRIPTION
Referencing the conversation in https://github.com/astral-sh/uv/issues/1386 some performance improvement should be seen in the ci pipeline. After getting this working it seems the dependency install time went from 12-15s to 2s.